### PR TITLE
update workflows for war/jar files and fixes

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -68,7 +68,9 @@ jobs:
         run: |
           for dir in ${{ env.FOLDERS }}; do
             echo "Building Docker image in directory: $dir"
-            IMAGE_TAG=$(basename $(find $dir/target -type f -name '*.war') .war )-$(echo ${{ github.sha }} | cut -c1-7)
+            FILE=$(find $dir/target -type f \( -name '*.war' -o -name '*.jar' \) | head -n 1)
+            BUILD_TYPE=${FILE##*.}  
+            IMAGE_TAG=$(basename $FILE .$BUILD_TYPE)-$(echo ${{ github.sha }} | cut -c1-7)
             ECR_IMAGE_REPOSITORY=917951871879.dkr.ecr.eu-west-1.amazonaws.com/${{ github.event.repository.name }}
           
             docker build -t $ECR_IMAGE_REPOSITORY:$IMAGE_TAG $dir

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -71,7 +71,7 @@ jobs:
             FILE=$(find $dir/target -type f \( -name '*.war' -o -name '*.jar' \) | head -n 1)
             BUILD_TYPE=${FILE##*.}  
             IMAGE_TAG=$(basename $FILE .$BUILD_TYPE)-$(echo ${{ github.sha }} | cut -c1-7)
-            ECR_IMAGE_REPOSITORY=917951871879.dkr.ecr.eu-west-1.amazonaws.com/${{ github.event.repository.name }}
+            ECR_IMAGE_REPOSITORY=917951871879.dkr.ecr.eu-west-1.amazonaws.com/${{ github.event.repository.name }}/$dir
           
             docker build -t $ECR_IMAGE_REPOSITORY:$IMAGE_TAG $dir
             docker push $ECR_IMAGE_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -103,7 +103,9 @@ jobs:
         run: |
           for dir in ${{ env.FOLDERS }}; do
             echo "Building Docker image in directory: $dir"
-            IMAGE_TAG=$(basename $(find $dir/target -type f -name '*.war') .war )-$(echo ${{ github.sha }} | cut -c1-7)
+            FILE=$(find $dir/target -type f \( -name '*.war' -o -name '*.jar' \) | head -n 1)
+            BUILD_TYPE=${FILE##*.}  
+            IMAGE_TAG=$(basename $FILE .$BUILD_TYPE)-$(echo ${{ github.sha }} | cut -c1-7)
             ECR_IMAGE_REPOSITORY=917951871879.dkr.ecr.eu-west-1.amazonaws.com/${{ github.event.repository.name }}
 
             docker build -t $ECR_IMAGE_REPOSITORY:$IMAGE_TAG $dir

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Create and Auto-Merge Pull Request
         run: |
           PROJECT_VERSION=$(git describe --tags --abbrev=0 | sed 's/^[^0-9]*//')
-          gh pr create --base main --head ${{ steps.name-release-branch.outputs.branch }} --title "Release of version $PROJECT_VERSION" --body "This PR merges the Maven release changes."
+          gh pr create --base ${{ github.event.repository.default_branch }} --head ${{ steps.name-release-branch.outputs.branch }} --title "Release of version $PROJECT_VERSION" --body "This PR merges the Maven release changes."
           gh pr merge ${{ steps.name-release-branch.outputs.branch }} --delete-branch --merge --admin
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Spring Boot applications are creating **jar** files instead of **war** file
we are creating **image**  tag based on **war/jar** file name with commit sha
so in this **PR,** I updated the workflows, so that it will work for both spring/spring boot applications, which have Dockerfile with generated artifacts(war/jar files)