### PR TITLE
Update Maven deployment options in workflow

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -18,8 +18,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       TZ: ${{ inputs.time-zone }}
-      MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-
+      MAVEN_ARGS: '--no-transfer-progress --color always'
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Maven Deploy
         run: |
-          mvn clean deploy -B -U -V -fae -ntp -DskipTests|| { echo "Maven Deploy failed."; exit 1; }
+          mvn clean deploy -B -U -V -fae  -DskipTests|| { echo "Maven Deploy failed."; exit 1; }
 
       - name: Find all folders with Dockerfile
         run: |

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       TZ: ${{ inputs.time-zone }}
-      MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      MAVEN_ARGS: '--no-transfer-progress --color always'
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       TZ: ${{ inputs.time-zone }}
-      MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      MAVEN_ARGS: '--no-transfer-progress --color always'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Replaced MAVEN_OPTS with MAVEN_ARGS for Maven deployment. Also use '--no-transferr-out' which seems to be for this use case. Also, since I guess we use batch, but colors can be displayed, use --color always.